### PR TITLE
[#2] Navigation 섹션 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3,6 +3,13 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+
+  --color-nav-bg: rgba(2, 8, 23, 0.8);
+  --color-nav-border: rgba(255, 255, 255, 0.1);
+  --color-nav-text: #ffffff;
+  --color-nav-text-muted: #cbd5e1;
+  --color-nav-pill: #334155;
+  --color-nav-hover: #1e293b;
 }
 
 @theme inline {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import "./globals.css";
+import Navigation from "@/components/Navigation";
 
 export const metadata: Metadata = {
   title: "Portfolio",
@@ -13,7 +14,10 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <Navigation />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,28 @@
 export default function Home() {
+  const sectionClassName =
+    "mx-auto min-h-screen max-w-5xl scroll-mt-16 px-6 py-24";
+
   return (
     <main>
-      <h1>Portfolio</h1>
+      <section id="intro" className={sectionClassName}>
+        <h1>Intro</h1>
+      </section>
+
+      <section id="profile" className={sectionClassName}>
+        <h1>Profile</h1>
+      </section>
+
+      <section id="skills" className={sectionClassName}>
+        <h1>Skills</h1>
+      </section>
+
+      <section id="experience" className={sectionClassName}>
+        <h1>Experience</h1>
+      </section>
+
+      <section id="contact" className={sectionClassName}>
+        <h1>Contact</h1>
+      </section>
     </main>
   );
 }

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,12 +44,15 @@ export default function Navigation() {
   }, []);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-white/10 bg-[#020817]/80 backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-(--color-nav-border) bg-(--color-nav-bg) backdrop-blur">
       <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-        <Link className="my-1 text-lg font-bold text-white" href="/">
+        <Link
+          className="my-1 text-lg font-bold text-(--color-nav-text)"
+          href="/"
+        >
           Portfolio
         </Link>
-        <ul className="flex items-center gap-6 text-sm font-medium text-slate-300">
+        <ul className="flex items-center gap-6 text-sm font-medium text-(--color-nav-text-muted)">
           {navItems.map((item) => {
             const isActive = activeSection === item.id;
 
@@ -59,8 +62,8 @@ export default function Navigation() {
                   href={item.href}
                   className={`rounded-full px-5 py-2.5 transition-all duration-200 ${
                     isActive
-                      ? "bg-slate-700 text-white"
-                      : "text-slate-300 hover:bg-slate-800 hover:text-white"
+                      ? "bg-(--color-nav-pill) text-(--color-nav-text)"
+                      : "text-(--color-nav-text-muted) hover:bg-(--color-nav-hover) hover:text-(--color-nav-text)"
                   }`}
                 >
                   {item.label}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -4,7 +4,6 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 
 const navItems = [
-  { label: "Intro", href: "#intro", id: "intro" },
   { label: "Profile", href: "#profile", id: "profile" },
   { label: "Skills", href: "#skills", id: "skills" },
   { label: "Experience", href: "#experience", id: "experience" },
@@ -12,7 +11,7 @@ const navItems = [
 ];
 
 export default function Navigation() {
-  const [activeSection, setActiveSection] = useState("intro");
+  const [activeSection, setActiveSection] = useState("profile");
 
   useEffect(() => {
     const sections = navItems

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+const navItems = [
+  { label: "Intro", href: "#intro", id: "intro" },
+  { label: "Profile", href: "#profile", id: "profile" },
+  { label: "Skills", href: "#skills", id: "skills" },
+  { label: "Experience", href: "#experience", id: "experience" },
+  { label: "Contact", href: "#contact", id: "contact" },
+];
+
+export default function Navigation() {
+  const [activeSection, setActiveSection] = useState("intro");
+
+  useEffect(() => {
+    const sections = navItems
+      .map((item) => document.getElementById(item.id))
+      .filter((section): section is HTMLElement => section !== null);
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const visibleSection = entries.find((entry) => entry.isIntersecting);
+        if (visibleSection) {
+          setActiveSection(visibleSection.target.id);
+        }
+      },
+      {
+        root: null,
+        rootMargin: "-40% 0px -40% 0px",
+        threshold: 0.1,
+      },
+    );
+
+    sections.forEach((section) => {
+      observer.observe(section);
+    });
+
+    return () => {
+      sections.forEach((section) => {
+        observer.unobserve(section);
+      });
+    };
+  }, []);
+
+  return (
+    <header className="sticky top-0 z-50 border-b border-white/10 bg-[#020817]/80 backdrop-blur">
+      <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
+        <Link className="my-1 text-lg font-bold text-white" href="/">
+          Portfolio
+        </Link>
+        <ul className="flex items-center gap-6 text-sm font-medium text-slate-300">
+          {navItems.map((item) => {
+            const isActive = activeSection === item.id;
+
+            return (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className={`rounded-full px-5 py-2.5 transition-all duration-200 ${
+                    isActive
+                      ? "bg-slate-700 text-white"
+                      : "text-slate-300 hover:bg-slate-800 hover:text-white"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+    </header>
+  );
+}


### PR DESCRIPTION
## Vercel 프리뷰 링크
[Preview 바로가기](https://portfolio-povlm07kb-jang-eunjaes-projects.vercel.app)

## 작업 UI 스크린샷
<img width="1027" height="353" alt="스크린샷 2026-03-11 오후 3 56 37" src="https://github.com/user-attachments/assets/6bda07d8-8e75-4c1c-bb6c-ce5a0a51ae8c" />
<img width="1027" height="353" alt="스크린샷 2026-03-11 오후 3 56 47" src="https://github.com/user-attachments/assets/1a8a794d-cf73-4659-b240-0cce19ee7557" />

## 작업 내용

포트폴리오 웹 페이지 상단 Navigation 섹션을 구현했습니다.

- Navigation bar 컴포넌트 구현
- `src/components/Navigation.tsx`에 저장
- sticky 적용으로 Navigation 상단 고정
- section scroll 이동 기능 구현
- 사용자가 현재 보고 있는 섹션에 따라 Navigation 메뉴 활성화 표시

## 피드백 받고 싶은 내용

1. Navigation 메뉴에서 'Intro' 항목을 유지하는 것이 좋을지, 제거하고 'Profile'부터 시작하는 것이 더 깔끔할지 의견이 궁금합니다.

## 관련 이슈

- Closes #2