### PR TITLE
[#2] Intro, Profile 섹션 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,43 +1,12 @@
+@import "../styles/tokens.css";
 @import "tailwindcss";
-
-:root {
-  --background: #ffffff;
-  --foreground: #171717;
-
-  /* navigation */
-  --color-nav-bg: rgba(2, 8, 23, 0.8);
-  --color-nav-border: rgba(255, 255, 255, 0.1);
-  --color-nav-text: #ffffff;
-  --color-nav-text-muted: #cbd5e1;
-  --color-nav-pill: #334155;
-  --color-nav-hover: #1e293b;
-
-  /* intro */
-  --color-intro-badge-bg: #1e293b;
-  --color-intro-button-bg: #334155;
-  --color-intro-button-hover: #475569;
-
-  /* profile */
-  --color-profile-card-bg: #0f172a;
-  --color-profile-card-border: rgba(255, 255, 255, 0.1);
-  --color-profile-button-bg: #0b1530;
-  --color-profile-button-hover: #162447;
-  --color-profile-blog-bg: #3a4a68;
-  --color-profile-blog-hover: #4a5d80;
-}
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
-}
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  --font-sans: var(--font-family-sans);
+  --font-mono: var(--font-family-mono);
 }
 
 html {
@@ -45,7 +14,8 @@ html {
 }
 
 body {
-  background: var(--background);
-  color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  min-height: 100vh;
+  background: var(--color-bg-canvas);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-sans);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -16,6 +16,14 @@
   --color-intro-badge-bg: #1e293b;
   --color-intro-button-bg: #334155;
   --color-intro-button-hover: #475569;
+
+  /* profile */
+  --color-profile-card-bg: #0f172a;
+  --color-profile-card-border: rgba(255, 255, 255, 0.1);
+  --color-profile-button-bg: #0b1530;
+  --color-profile-button-hover: #162447;
+  --color-profile-blog-bg: #3a4a68;
+  --color-profile-blog-hover: #4a5d80;
 }
 
 @theme inline {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,13 +1,5 @@
-@import "../styles/tokens.css";
 @import "tailwindcss";
-
-@theme inline {
-  --color-background: var(--background);
-  --color-foreground: var(--foreground);
-
-  --font-sans: var(--font-family-sans);
-  --font-mono: var(--font-family-mono);
-}
+@import "../styles/tokens.css";
 
 html {
   scroll-behavior: smooth;
@@ -17,5 +9,5 @@ body {
   min-height: 100vh;
   background: var(--color-bg-canvas);
   color: var(--color-text-primary);
-  font-family: var(--font-family-sans);
+  font-family: var(--font-sans);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,12 +4,18 @@
   --background: #ffffff;
   --foreground: #171717;
 
+  /* navigation */
   --color-nav-bg: rgba(2, 8, 23, 0.8);
   --color-nav-border: rgba(255, 255, 255, 0.1);
   --color-nav-text: #ffffff;
   --color-nav-text-muted: #cbd5e1;
   --color-nav-pill: #334155;
   --color-nav-hover: #1e293b;
+
+  /* intro */
+  --color-intro-badge-bg: #1e293b;
+  --color-intro-button-bg: #334155;
+  --color-intro-button-hover: #475569;
 }
 
 @theme inline {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,23 +1,21 @@
+import SectionLayout from "@/components/SectionLayout";
 import Intro from "@/sections/Intro";
 import Profile from "@/sections/Profile";
 
 export default function Home() {
-  const sectionClassName =
-    "mx-auto min-h-screen max-w-5xl scroll-mt-16 px-6 py-24";
-
   return (
     <main>
       <Intro />
       <Profile />
-      <section id="skills" className={sectionClassName}>
+      <SectionLayout id="skills" fullHeight>
         <h1>Skills</h1>
-      </section>
-      <section id="experience" className={sectionClassName}>
+      </SectionLayout>
+      <SectionLayout id="experience" fullHeight>
         <h1>Experience</h1>
-      </section>
-      <section id="contact" className={sectionClassName}>
+      </SectionLayout>
+      <SectionLayout id="contact" fullHeight>
         <h1>Contact</h1>
-      </section>
+      </SectionLayout>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import Intro from "@/sections/Intro";
+import Profile from "@/sections/Profile";
 
 export default function Home() {
   const sectionClassName =
@@ -10,8 +11,8 @@ export default function Home() {
         <Intro />
       </section>
 
-      <section id="profile" className={sectionClassName}>
-        <h1>Profile</h1>
+      <section id="profile">
+        <Profile />
       </section>
 
       <section id="skills" className={sectionClassName}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,22 +7,14 @@ export default function Home() {
 
   return (
     <main>
-      <section id="intro">
-        <Intro />
-      </section>
-
-      <section id="profile">
-        <Profile />
-      </section>
-
+      <Intro />
+      <Profile />
       <section id="skills" className={sectionClassName}>
         <h1>Skills</h1>
       </section>
-
       <section id="experience" className={sectionClassName}>
         <h1>Experience</h1>
       </section>
-
       <section id="contact" className={sectionClassName}>
         <h1>Contact</h1>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
+import Intro from "@/sections/Intro";
+
 export default function Home() {
   const sectionClassName =
     "mx-auto min-h-screen max-w-5xl scroll-mt-16 px-6 py-24";
 
   return (
     <main>
-      <section id="intro" className={sectionClassName}>
-        <h1>Intro</h1>
+      <section id="intro">
+        <Intro />
       </section>
 
       <section id="profile" className={sectionClassName}>

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,15 +44,16 @@ export default function Navigation() {
   }, []);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-(--color-nav-border) bg-(--color-nav-bg) backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-(--color-border-subtle) bg-(--color-surface-nav) backdrop-blur">
       <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
         <Link
-          className="my-1 text-lg font-bold text-(--color-nav-text)"
+          className="my-1 text-lg font-bold text-(--color-text-primary)"
           href="/"
         >
           Portfolio
         </Link>
-        <ul className="flex items-center gap-6 text-sm font-medium text-(--color-nav-text-muted)">
+
+        <ul className="flex items-center gap-6 text-sm font-medium text-(--color-text-secondary)">
           {navItems.map((item) => {
             const isActive = activeSection === item.id;
 
@@ -62,8 +63,8 @@ export default function Navigation() {
                   href={item.href}
                   className={`rounded-full px-5 py-2.5 transition-all duration-200 ${
                     isActive
-                      ? "bg-(--color-nav-pill) text-(--color-nav-text)"
-                      : "text-(--color-nav-text-muted) hover:bg-(--color-nav-hover) hover:text-(--color-nav-text)"
+                      ? "bg-(--color-surface-pill) text-(--color-text-primary)"
+                      : "text-(--color-text-secondary) hover:bg-(--color-surface-badge) hover:text-(--color-text-primary)"
                   }`}
                 >
                   {item.label}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -44,16 +44,13 @@ export default function Navigation() {
   }, []);
 
   return (
-    <header className="sticky top-0 z-50 border-b border-(--color-border-subtle) bg-(--color-surface-nav) backdrop-blur">
+    <header className="sticky top-0 z-50 border-b border-border-subtle bg-surface-nav backdrop-blur">
       <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-        <Link
-          className="my-1 text-lg font-bold text-(--color-text-primary)"
-          href="/"
-        >
+        <Link className="my-1 text-lg font-bold text-text-primary" href="/">
           Portfolio
         </Link>
 
-        <ul className="flex items-center gap-6 text-sm font-medium text-(--color-text-secondary)">
+        <ul className="flex items-center gap-6 text-sm font-medium text-text-secondary">
           {navItems.map((item) => {
             const isActive = activeSection === item.id;
 
@@ -63,8 +60,8 @@ export default function Navigation() {
                   href={item.href}
                   className={`rounded-full px-5 py-2.5 transition-all duration-200 ${
                     isActive
-                      ? "bg-(--color-surface-pill) text-(--color-text-primary)"
-                      : "text-(--color-text-secondary) hover:bg-(--color-surface-badge) hover:text-(--color-text-primary)"
+                      ? "bg-surface-pill text-text-primary"
+                      : "text-text-secondary hover:bg-surface-badge hover:text-text-primary"
                   }`}
                 >
                   {item.label}

--- a/src/components/PillLink.tsx
+++ b/src/components/PillLink.tsx
@@ -1,0 +1,36 @@
+import type { AnchorHTMLAttributes, ReactNode } from "react";
+
+type PillLinkProps = {
+  children: ReactNode;
+  href: string;
+  variant?: "primary" | "secondary" | "outline";
+} & AnchorHTMLAttributes<HTMLAnchorElement>;
+
+const variantClassNames = {
+  primary: "bg-surface-pill hover:bg-surface-pill-hover",
+  secondary: "bg-surface-secondary hover:bg-surface-secondary-hover",
+  outline:
+    "border border-border-subtle bg-surface-pill hover:bg-surface-pill-hover",
+};
+
+export default function PillLink({
+  children,
+  href,
+  variant = "primary",
+  className = "",
+  ...props
+}: PillLinkProps) {
+  const classes = [
+    "rounded-full text-sm font-semibold text-text-primary transition-colors",
+    variantClassNames[variant],
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <a href={href} className={classes} {...props}>
+      {children}
+    </a>
+  );
+}

--- a/src/components/SectionHeader.tsx
+++ b/src/components/SectionHeader.tsx
@@ -1,0 +1,14 @@
+type SectionHeaderProps = {
+  title: string;
+};
+
+export default function SectionHeader({ title }: SectionHeaderProps) {
+  return (
+    <div className="mb-8 flex items-center gap-4">
+      <div className="h-8 w-1 rounded-full bg-text-primary" />
+      <h2 className="text-base font-bold tracking-wide text-text-primary">
+        {title}
+      </h2>
+    </div>
+  );
+}

--- a/src/components/SectionLayout.tsx
+++ b/src/components/SectionLayout.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+type SectionLayoutProps = {
+  id: string;
+  children: ReactNode;
+  className?: string;
+  fullHeight?: boolean;
+};
+
+export default function SectionLayout({
+  id,
+  children,
+  className = "",
+  fullHeight = false,
+}: SectionLayoutProps) {
+  const classes = [
+    "mx-auto max-w-5xl scroll-mt-16 px-6 py-24",
+    fullHeight ? "min-h-screen" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <section id={id} className={classes}>
+      {children}
+    </section>
+  );
+}

--- a/src/sections/Intro.tsx
+++ b/src/sections/Intro.tsx
@@ -4,21 +4,21 @@ export default function Intro() {
       id="intro"
       className="mx-auto flex min-h-screen max-w-5xl scroll-mt-16 flex-col items-center justify-center px-6 text-center"
     >
-      <div className="mb-6 rounded-full bg-slate-800 px-5 py-2 text-sm text-slate-300">
+      <div className="mb-6 rounded-full bg-(--color-intro-badge-bg) px-5 py-2 text-sm text-(--color-nav-text-muted)">
         👋 Welcome to my portfolio
       </div>
       <h1 className="mb-8 text-5xl font-bold leading-tight md:text-7xl">
         한 줄 소개가 들어갈 자리
       </h1>
-      <p className="mb-1 text-lg text-slate-300 md:text-xl">
+      <p className="mb-1 text-lg text-(--color-nav-text-muted) md:text-xl">
         여기에 간단한 자기소개 문장이 들어갑니다.
       </p>
-      <p className="mb-7 text-lg text-slate-300 md:text-xl">
+      <p className="mb-7 text-lg text-(--color-nav-text-muted) md:text-xl">
         두 줄 정도의 간단한 소개 텍스트를 배치할 예정입니다.
       </p>
       <a
         href="#contact"
-        className="rounded-full bg-slate-700 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-600"
+        className="rounded-full bg-(--color-intro-button-bg) px-6 py-2.5 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-intro-button-hover)"
       >
         Contact me →
       </a>

--- a/src/sections/Intro.tsx
+++ b/src/sections/Intro.tsx
@@ -1,0 +1,27 @@
+export default function Intro() {
+  return (
+    <section
+      id="intro"
+      className="mx-auto flex min-h-screen max-w-5xl scroll-mt-16 flex-col items-center justify-center px-6 text-center"
+    >
+      <div className="mb-6 rounded-full bg-slate-800 px-5 py-2 text-sm text-slate-300">
+        👋 Welcome to my portfolio
+      </div>
+      <h1 className="mb-8 text-5xl font-bold leading-tight md:text-7xl">
+        한 줄 소개가 들어갈 자리
+      </h1>
+      <p className="mb-1 text-lg text-slate-300 md:text-xl">
+        여기에 간단한 자기소개 문장이 들어갑니다.
+      </p>
+      <p className="mb-7 text-lg text-slate-300 md:text-xl">
+        두 줄 정도의 간단한 소개 텍스트를 배치할 예정입니다.
+      </p>
+      <a
+        href="#contact"
+        className="rounded-full bg-slate-700 px-6 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-slate-600"
+      >
+        Contact me →
+      </a>
+    </section>
+  );
+}

--- a/src/sections/Intro.tsx
+++ b/src/sections/Intro.tsx
@@ -4,7 +4,7 @@ export default function Intro() {
       id="intro"
       className="mx-auto flex min-h-screen max-w-5xl scroll-mt-16 flex-col items-center justify-center px-6 text-center"
     >
-      <div className="mb-6 rounded-full bg-(--color-surface-badge) px-5 py-2 text-sm text-(--color-text-secondary)">
+      <div className="mb-6 rounded-full bg-surface-badge px-5 py-2 text-sm text-text-secondary">
         👋 Welcome to my portfolio
       </div>
 
@@ -12,16 +12,16 @@ export default function Intro() {
         한 줄 소개가 들어갈 자리
       </h1>
 
-      <p className="mb-1 text-lg text-(--color-text-secondary) md:text-xl">
+      <p className="mb-1 text-lg text-text-secondary md:text-xl">
         여기에 간단한 자기소개 문장이 들어갑니다.
       </p>
-      <p className="mb-7 text-lg text-(--color-text-secondary) md:text-xl">
+      <p className="mb-7 text-lg text-text-secondary md:text-xl">
         두 줄 정도의 간단한 소개 텍스트를 배치할 예정입니다.
       </p>
 
       <a
         href="#contact"
-        className="rounded-full bg-(--color-surface-pill) px-6 py-2.5 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-pill-hover)"
+        className="rounded-full bg-surface-pill px-6 py-2.5 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-pill-hover"
       >
         Contact me →
       </a>

--- a/src/sections/Intro.tsx
+++ b/src/sections/Intro.tsx
@@ -4,21 +4,24 @@ export default function Intro() {
       id="intro"
       className="mx-auto flex min-h-screen max-w-5xl scroll-mt-16 flex-col items-center justify-center px-6 text-center"
     >
-      <div className="mb-6 rounded-full bg-(--color-intro-badge-bg) px-5 py-2 text-sm text-(--color-nav-text-muted)">
+      <div className="mb-6 rounded-full bg-(--color-surface-badge) px-5 py-2 text-sm text-(--color-text-secondary)">
         👋 Welcome to my portfolio
       </div>
+
       <h1 className="mb-8 text-5xl font-bold leading-tight md:text-7xl">
         한 줄 소개가 들어갈 자리
       </h1>
-      <p className="mb-1 text-lg text-(--color-nav-text-muted) md:text-xl">
+
+      <p className="mb-1 text-lg text-(--color-text-secondary) md:text-xl">
         여기에 간단한 자기소개 문장이 들어갑니다.
       </p>
-      <p className="mb-7 text-lg text-(--color-nav-text-muted) md:text-xl">
+      <p className="mb-7 text-lg text-(--color-text-secondary) md:text-xl">
         두 줄 정도의 간단한 소개 텍스트를 배치할 예정입니다.
       </p>
+
       <a
         href="#contact"
-        className="rounded-full bg-(--color-intro-button-bg) px-6 py-2.5 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-intro-button-hover)"
+        className="rounded-full bg-(--color-surface-pill) px-6 py-2.5 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-pill-hover)"
       >
         Contact me →
       </a>

--- a/src/sections/Intro.tsx
+++ b/src/sections/Intro.tsx
@@ -1,8 +1,12 @@
+import PillLink from "@/components/PillLink";
+import SectionLayout from "@/components/SectionLayout";
+
 export default function Intro() {
   return (
-    <section
+    <SectionLayout
       id="intro"
-      className="mx-auto flex min-h-screen max-w-5xl scroll-mt-16 flex-col items-center justify-center px-6 text-center"
+      fullHeight
+      className="flex flex-col items-center justify-center text-center"
     >
       <div className="mb-6 rounded-full bg-surface-badge px-5 py-2 text-sm text-text-secondary">
         👋 Welcome to my portfolio
@@ -19,12 +23,9 @@ export default function Intro() {
         두 줄 정도의 간단한 소개 텍스트를 배치할 예정입니다.
       </p>
 
-      <a
-        href="#contact"
-        className="rounded-full bg-surface-pill px-6 py-2.5 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-pill-hover"
-      >
+      <PillLink href="#contact" className="px-6 py-2.5">
         Contact me →
-      </a>
-    </section>
+      </PillLink>
+    </SectionLayout>
   );
 }

--- a/src/sections/Profile.tsx
+++ b/src/sections/Profile.tsx
@@ -1,12 +1,11 @@
+import PillLink from "@/components/PillLink";
+import SectionHeader from "@/components/SectionHeader";
+import SectionLayout from "@/components/SectionLayout";
+
 export default function Profile() {
   return (
-    <section id="profile" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
-      <div className="mb-8 flex items-center gap-4">
-        <div className="h-8 w-1 rounded-full bg-text-primary" />
-        <h2 className="text-base font-bold tracking-wide text-text-primary">
-          PROFILE
-        </h2>
-      </div>
+    <SectionLayout id="profile">
+      <SectionHeader title="PROFILE" />
 
       <div className="mx-auto max-w-302.5 rounded-4xl border border-border-subtle bg-surface-card px-16 pt-16 pb-12 shadow-lg">
         <div className="mx-auto grid max-w-3xl grid-cols-2 gap-16">
@@ -28,25 +27,27 @@ export default function Profile() {
         </div>
 
         <div className="mt-12 flex justify-center gap-4">
-          <a
+          <PillLink
             href="https://github.com/eae22"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full bg-surface-secondary px-7 py-2 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-secondary-hover"
+            variant="secondary"
+            className="px-7 py-2"
           >
             GitHub →
-          </a>
+          </PillLink>
 
-          <a
+          <PillLink
             href="https://blog.naver.com/eae0110"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full border border-border-subtle bg-surface-pill px-7 py-2 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-pill-hover"
+            variant="outline"
+            className="px-7 py-2"
           >
             Blog →
-          </a>
+          </PillLink>
         </div>
       </div>
-    </section>
+    </SectionLayout>
   );
 }

--- a/src/sections/Profile.tsx
+++ b/src/sections/Profile.tsx
@@ -1,0 +1,50 @@
+export default function Profile() {
+  return (
+    <section id="profile" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
+      <div className="mb-8 flex items-center gap-4">
+        <div className="h-8 w-1 rounded-full bg-(--color-nav-text)" />
+        <h2 className="text-base font-bold tracking-wide text-(--color-nav-text)">
+          PROFILE
+        </h2>
+      </div>
+      <div className="mx-auto max-w-302.5 rounded-4xl border border-(--color-profile-card-border) bg-(--color-profile-card-bg) px-16 pt-16 pb-12 shadow-lg">
+        <div className="mx-auto grid max-w-3xl grid-cols-2 gap-16">
+          <div className="space-y-5 text-right">
+            <h3 className="text-lg font-semibold text-(--color-nav-text)">
+              Eunjae Jang (장은재)
+            </h3>
+            <p className="text-base text-(--color-nav-text-muted)">
+              Dongguk University, Senior
+            </p>
+          </div>
+          <div className="space-y-5">
+            <p className="text-lg font-medium text-(--color-nav-text)">
+              Seoul, South Korea
+            </p>
+            <p className="text-base text-(--color-nav-text-muted)">
+              eun0110@dgu.ac.kr
+            </p>
+          </div>
+        </div>
+        <div className="mt-12 flex justify-center gap-4">
+          <a
+            href="https://github.com/eae22"
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full bg-(--color-profile-button-bg) px-7 py-2 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-profile-button-hover)"
+          >
+            GitHub →
+          </a>
+          <a
+            href="https://blog.naver.com/eae0110"
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-full border border-(--color-profile-card-border) bg-(--color-profile-blog-bg) px-7 py-2 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-profile-blog-hover)"
+          >
+            Blog →
+          </a>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Profile.tsx
+++ b/src/sections/Profile.tsx
@@ -2,44 +2,48 @@ export default function Profile() {
   return (
     <section id="profile" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
       <div className="mb-8 flex items-center gap-4">
-        <div className="h-8 w-1 rounded-full bg-(--color-nav-text)" />
-        <h2 className="text-base font-bold tracking-wide text-(--color-nav-text)">
+        <div className="h-8 w-1 rounded-full bg-(--color-text-primary)" />
+        <h2 className="text-base font-bold tracking-wide text-(--color-text-primary)">
           PROFILE
         </h2>
       </div>
-      <div className="mx-auto max-w-302.5 rounded-4xl border border-(--color-profile-card-border) bg-(--color-profile-card-bg) px-16 pt-16 pb-12 shadow-lg">
+
+      <div className="mx-auto max-w-302.5 rounded-4xl border border-(--color-border-subtle) bg-(--color-surface-card) px-16 pt-16 pb-12 shadow-lg">
         <div className="mx-auto grid max-w-3xl grid-cols-2 gap-16">
           <div className="space-y-5 text-right">
-            <h3 className="text-lg font-semibold text-(--color-nav-text)">
+            <h3 className="text-lg font-semibold text-(--color-text-primary)">
               Eunjae Jang (장은재)
             </h3>
-            <p className="text-base text-(--color-nav-text-muted)">
+            <p className="text-base text-(--color-text-secondary)">
               Dongguk University, Senior
             </p>
           </div>
+
           <div className="space-y-5">
-            <p className="text-lg font-medium text-(--color-nav-text)">
+            <p className="text-lg font-medium text-(--color-text-primary)">
               Seoul, South Korea
             </p>
-            <p className="text-base text-(--color-nav-text-muted)">
+            <p className="text-base text-(--color-text-secondary)">
               eun0110@dgu.ac.kr
             </p>
           </div>
         </div>
+
         <div className="mt-12 flex justify-center gap-4">
           <a
             href="https://github.com/eae22"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full bg-(--color-profile-button-bg) px-7 py-2 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-profile-button-hover)"
+            className="rounded-full bg-(--color-surface-secondary) px-7 py-2 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-secondary-hover)"
           >
             GitHub →
           </a>
+
           <a
             href="https://blog.naver.com/eae0110"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full border border-(--color-profile-card-border) bg-(--color-profile-blog-bg) px-7 py-2 text-sm font-semibold text-(--color-nav-text) transition-colors hover:bg-(--color-profile-blog-hover)"
+            className="rounded-full border border-(--color-border-subtle) bg-(--color-surface-pill) px-7 py-2 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-pill-hover)"
           >
             Blog →
           </a>

--- a/src/sections/Profile.tsx
+++ b/src/sections/Profile.tsx
@@ -2,30 +2,28 @@ export default function Profile() {
   return (
     <section id="profile" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
       <div className="mb-8 flex items-center gap-4">
-        <div className="h-8 w-1 rounded-full bg-(--color-text-primary)" />
-        <h2 className="text-base font-bold tracking-wide text-(--color-text-primary)">
+        <div className="h-8 w-1 rounded-full bg-text-primary" />
+        <h2 className="text-base font-bold tracking-wide text-text-primary">
           PROFILE
         </h2>
       </div>
 
-      <div className="mx-auto max-w-302.5 rounded-4xl border border-(--color-border-subtle) bg-(--color-surface-card) px-16 pt-16 pb-12 shadow-lg">
+      <div className="mx-auto max-w-302.5 rounded-4xl border border-border-subtle bg-surface-card px-16 pt-16 pb-12 shadow-lg">
         <div className="mx-auto grid max-w-3xl grid-cols-2 gap-16">
           <div className="space-y-5 text-right">
-            <h3 className="text-lg font-semibold text-(--color-text-primary)">
+            <h3 className="text-lg font-semibold text-text-primary">
               Eunjae Jang (장은재)
             </h3>
-            <p className="text-base text-(--color-text-secondary)">
+            <p className="text-base text-text-secondary">
               Dongguk University, Senior
             </p>
           </div>
 
           <div className="space-y-5">
-            <p className="text-lg font-medium text-(--color-text-primary)">
+            <p className="text-lg font-medium text-text-primary">
               Seoul, South Korea
             </p>
-            <p className="text-base text-(--color-text-secondary)">
-              eun0110@dgu.ac.kr
-            </p>
+            <p className="text-base text-text-secondary">eun0110@dgu.ac.kr</p>
           </div>
         </div>
 
@@ -34,7 +32,7 @@ export default function Profile() {
             href="https://github.com/eae22"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full bg-(--color-surface-secondary) px-7 py-2 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-secondary-hover)"
+            className="rounded-full bg-surface-secondary px-7 py-2 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-secondary-hover"
           >
             GitHub →
           </a>
@@ -43,7 +41,7 @@ export default function Profile() {
             href="https://blog.naver.com/eae0110"
             target="_blank"
             rel="noreferrer"
-            className="rounded-full border border-(--color-border-subtle) bg-(--color-surface-pill) px-7 py-2 text-sm font-semibold text-(--color-text-primary) transition-colors hover:bg-(--color-surface-pill-hover)"
+            className="rounded-full border border-border-subtle bg-surface-pill px-7 py-2 text-sm font-semibold text-text-primary transition-colors hover:bg-surface-pill-hover"
           >
             Blog →
           </a>

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,10 +1,9 @@
 :root {
   color-scheme: dark;
+  --copy-pop-distance: -4px;
+}
 
-  /* base */
-  --background: #020817;
-  --foreground: #ffffff;
-
+@theme inline {
   /* text */
   --color-text-primary: #ffffff;
   --color-text-secondary: #cbd5e1;
@@ -23,6 +22,7 @@
   /* border */
   --color-border-subtle: rgb(255 255 255 / 0.1);
   --color-border-strong: rgb(255 255 255 / 0.16);
+  --color-border-accent: rgb(96 165 250 / 0.8);
 
   /* radius */
   --radius-sm: 12px;
@@ -37,15 +37,23 @@
   --duration-fast: 150ms;
   --duration-normal: 250ms;
   --duration-slow: 400ms;
+  --duration-emphasis: 600ms;
+
   --ease-standard: ease;
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);
+  --ease-bounce: cubic-bezier(0.34, 1.56, 0.64, 1);
 
   /* typography */
-  --font-size-hero: 4rem;
-  --font-size-body-lg: 1.25rem;
-  --font-size-section-title: 1rem;
-  --letter-spacing-section: 0.08em;
+  --text-hero: 4rem;
+  --text-body-lg: 1.25rem;
+  --text-section-title: 1rem;
+  --tracking-section: 0.08em;
 
   /* font */
-  --font-family-sans: var(--font-geist-sans), Arial, Helvetica, sans-serif;
-  --font-family-mono: var(--font-geist-mono), monospace;
+  --font-sans: var(--font-geist-sans), Arial, Helvetica, sans-serif;
+  --font-mono: var(--font-geist-mono), monospace;
+
+  /* contact / accent */
+  --color-bg-inverse: #ffffff;
+  --color-text-on-inverse: #334155;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,0 +1,51 @@
+:root {
+  color-scheme: dark;
+
+  /* base */
+  --background: #020817;
+  --foreground: #ffffff;
+
+  /* text */
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #cbd5e1;
+  --color-text-tertiary: #94a3b8;
+
+  /* surface */
+  --color-bg-canvas: #020817;
+  --color-surface-nav: rgb(2 8 23 / 0.8);
+  --color-surface-card: #0f172a;
+  --color-surface-badge: #1e293b;
+  --color-surface-pill: #334155;
+  --color-surface-pill-hover: #475569;
+  --color-surface-secondary: #0b1530;
+  --color-surface-secondary-hover: #162447;
+
+  /* border */
+  --color-border-subtle: rgb(255 255 255 / 0.1);
+  --color-border-strong: rgb(255 255 255 / 0.16);
+
+  /* radius */
+  --radius-sm: 12px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
+  --radius-full: 9999px;
+
+  /* shadow */
+  --shadow-card: 0 8px 24px rgb(0 0 0 / 0.12);
+
+  /* motion */
+  --duration-fast: 150ms;
+  --duration-normal: 250ms;
+  --duration-slow: 400ms;
+  --ease-standard: ease;
+
+  /* typography */
+  --font-size-hero: 4rem;
+  --font-size-body-lg: 1.25rem;
+  --font-size-section-title: 1rem;
+  --letter-spacing-section: 0.08em;
+
+  /* font */
+  --font-family-sans: var(--font-geist-sans), Arial, Helvetica, sans-serif;
+  --font-family-mono: var(--font-geist-mono), monospace;
+}


### PR DESCRIPTION
## Vercel 프리뷰 링크
[Preview 바로가기](https://portfolio-git-feat-intro-profile-jang-eunjaes-projects.vercel.app/)


## 작업 UI 스크린샷
### Intro 섹션
<img width="1008" height="551" alt="스크린샷 2026-03-25 오후 4 13 28" src="https://github.com/user-attachments/assets/e2639840-9dc5-41b0-a08b-ba81ceec3a2b" />

### Profile 섹션
<img width="1008" height="551" alt="스크린샷 2026-03-25 오후 4 13 41" src="https://github.com/user-attachments/assets/6d1056b1-30d9-429c-9703-6eef250eb06f" />


## 작업 내용

포트폴리오 웹 페이지의 Intro, Profile 섹션을 구현하고, 전반적인 스타일 구조를 CSS 토큰 기반으로 정리했습니다.

### Intro 섹션 구현
- `src/sections/Intro.tsx`에 저장
- 메인 소개 문구, 짧은 자기소개 텍스트, Contact 버튼 배치
- `#contact` 섹션으로 바로 이동할 수 있도록 CTA 링크 연결

### Profile 섹션 구현
- `src/sections/Profile.tsx`에 저장
- 이름, 소속, 위치, 이메일 등 기본 프로필 정보 구성
- GitHub, Blog 외부 링크 버튼 추가

### 스타일 구조 개선
- `src/styles/tokens.css`에 색상, radius, shadow, typography 등 디자인 토큰 정리
- Intro, Profile, Navigation에서 공통 토큰을 사용하도록 리팩토링
- `src/app/globals.css`에서 전역 배경색, 폰트, 스크롤 동작 정리

</br>

- 애니메이션은 추후 전체 섹션 구성이 어느 정도 마무리된 뒤, 페이지 전반의 흐름에 맞춰 추가 구현할 예정입니다.

## 피드백 받고 싶은 내용  
1. CSS 토큰 기반으로 스타일을 정리했는데, 네이밍이나 구조에서 어색한 부분이 있는지도 피드백 받고 싶습니다.

## 관련 이슈

- Refs #2