### PR TITLE
[#3] Skills 섹션 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# Codex용 로컬 PR 템플릿
+.codex/

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,15 +1,14 @@
 import SectionLayout from "@/components/SectionLayout";
 import Intro from "@/sections/Intro";
 import Profile from "@/sections/Profile";
+import Skills from "@/sections/Skills";
 
 export default function Home() {
   return (
     <main>
       <Intro />
       <Profile />
-      <SectionLayout id="skills" fullHeight>
-        <h1>Skills</h1>
-      </SectionLayout>
+      <Skills />
       <SectionLayout id="experience" fullHeight>
         <h1>Experience</h1>
       </SectionLayout>

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -1,0 +1,48 @@
+export type SkillCategory =
+  | "all"
+  | "languages"
+  | "frontend"
+  | "backend"
+  | "tools";
+
+export interface SkillCategoryOption {
+  label: string;
+  value: SkillCategory;
+}
+
+export interface SkillItem {
+  name: string;
+  icon: string | string[];
+  categories: Exclude<SkillCategory, "all">[];
+}
+
+export const skillCategories: SkillCategoryOption[] = [
+  { label: "All", value: "all" },
+  { label: "Languages", value: "languages" },
+  { label: "Frontend", value: "frontend" },
+  { label: "Backend", value: "backend" },
+  { label: "Tools", value: "tools" },
+];
+
+export const skills: SkillItem[] = [
+  // Languages
+  { name: "JavaScript", icon: "javascript", categories: ["languages"] },
+  { name: "TypeScript", icon: "typescript", categories: ["languages"] },
+  { name: "Python", icon: "python", categories: ["languages"] },
+  { name: "C", icon: "c", categories: ["languages"] },
+
+  // Frontend
+  { name: "React", icon: "react", categories: ["frontend"] },
+  { name: "Next.js", icon: "nextdotjs", categories: ["frontend"] },
+  { name: "HTML/CSS", icon: ["html5", "css"], categories: ["frontend"] },
+  { name: "Tailwind CSS", icon: "tailwindcss", categories: ["frontend"] },
+
+  // Backend
+  { name: "Node.js", icon: "nodedotjs", categories: ["backend"] },
+  { name: "MySQL", icon: "mysql", categories: ["backend"] },
+
+  // Tools
+  { name: "Git", icon: "git", categories: ["tools"] },
+  { name: "Figma", icon: "figma", categories: ["tools"] },
+  { name: "Docker", icon: "docker", categories: ["tools"] },
+];

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -5,6 +5,22 @@ export type SkillCategory =
   | "backend"
   | "tools";
 
+export type SkillAccent =
+  | "javascript"
+  | "typescript"
+  | "python"
+  | "c"
+  | "react"
+  | "nextjs"
+  | "html"
+  | "css"
+  | "tailwind"
+  | "nodejs"
+  | "mysql"
+  | "git"
+  | "figma"
+  | "docker";
+
 export interface SkillCategoryOption {
   label: string;
   value: SkillCategory;
@@ -14,6 +30,8 @@ export interface SkillItem {
   name: string;
   icon: string | string[];
   categories: Exclude<SkillCategory, "all">[];
+  accent: SkillAccent;
+  secondaryAccent?: SkillAccent;
 }
 
 export const skillCategories: SkillCategoryOption[] = [
@@ -26,23 +44,59 @@ export const skillCategories: SkillCategoryOption[] = [
 
 export const skills: SkillItem[] = [
   // Languages
-  { name: "JavaScript", icon: "javascript", categories: ["languages"] },
-  { name: "TypeScript", icon: "typescript", categories: ["languages"] },
-  { name: "Python", icon: "python", categories: ["languages"] },
-  { name: "C", icon: "c", categories: ["languages"] },
+  {
+    name: "JavaScript",
+    icon: "javascript",
+    categories: ["languages"],
+    accent: "javascript",
+  },
+  {
+    name: "TypeScript",
+    icon: "typescript",
+    categories: ["languages"],
+    accent: "typescript",
+  },
+  {
+    name: "Python",
+    icon: "python",
+    categories: ["languages"],
+    accent: "python",
+  },
+  { name: "C", icon: "c", categories: ["languages"], accent: "c" },
 
   // Frontend
-  { name: "React", icon: "react", categories: ["frontend"] },
-  { name: "Next.js", icon: "nextdotjs", categories: ["frontend"] },
-  { name: "HTML/CSS", icon: ["html5", "css"], categories: ["frontend"] },
-  { name: "Tailwind CSS", icon: "tailwindcss", categories: ["frontend"] },
+  { name: "React", icon: "react", categories: ["frontend"], accent: "react" },
+  {
+    name: "Next.js",
+    icon: "nextdotjs",
+    categories: ["frontend"],
+    accent: "nextjs",
+  },
+  {
+    name: "HTML/CSS",
+    icon: ["html5", "css"],
+    categories: ["frontend"],
+    accent: "html",
+    secondaryAccent: "css",
+  },
+  {
+    name: "Tailwind CSS",
+    icon: "tailwindcss",
+    categories: ["frontend"],
+    accent: "tailwind",
+  },
 
   // Backend
-  { name: "Node.js", icon: "nodedotjs", categories: ["backend"] },
-  { name: "MySQL", icon: "mysql", categories: ["backend"] },
+  {
+    name: "Node.js",
+    icon: "nodedotjs",
+    categories: ["backend"],
+    accent: "nodejs",
+  },
+  { name: "MySQL", icon: "mysql", categories: ["backend"], accent: "mysql" },
 
   // Tools
-  { name: "Git", icon: "git", categories: ["tools"] },
-  { name: "Figma", icon: "figma", categories: ["tools"] },
-  { name: "Docker", icon: "docker", categories: ["tools"] },
+  { name: "Git", icon: "git", categories: ["tools"], accent: "git" },
+  { name: "Figma", icon: "figma", categories: ["tools"], accent: "figma" },
+  { name: "Docker", icon: "docker", categories: ["tools"], accent: "docker" },
 ];

--- a/src/sections/Skills.module.css
+++ b/src/sections/Skills.module.css
@@ -1,0 +1,334 @@
+.section {
+  --skill-filter-group-shadow: 0 22px 48px rgb(2 8 23 / 0.18);
+  --skill-filter-shadow: 0 10px 24px rgb(2 8 23 / 0.14);
+  --skill-filter-active-shadow: 0 16px 32px rgb(2 8 23 / 0.22);
+  --skill-chip-shadow: 0 10px 24px rgb(15 23 42 / 0.08);
+  --skill-chip-hover-shadow: 0 18px 32px rgb(15 23 42 / 0.14);
+  --skill-chip-enter-distance: 14px;
+}
+
+.filterGroup {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+  padding: 0.5rem;
+  border: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 88%, white 12%);
+  border-radius: calc(var(--radius-full) + 6px);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.01)),
+    linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-surface-card) 84%,
+        var(--color-surface-pill) 16%
+      ),
+      color-mix(in srgb, var(--color-surface-secondary) 88%, black 12%)
+    );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.05),
+    var(--skill-filter-group-shadow);
+}
+
+.filterButton {
+  --filter-accent: var(--color-border-accent);
+  position: relative;
+  isolation: isolate;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  overflow: hidden;
+  padding: 0.5rem 1.25rem;
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  opacity: 0.54;
+  box-shadow: none;
+  transition:
+    color var(--duration-normal) var(--ease-out),
+    opacity var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.filterButton::before,
+.filterButton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  transition:
+    opacity var(--duration-normal) var(--ease-out),
+    transform var(--duration-emphasis) var(--ease-out);
+}
+
+.filterButton::before {
+  z-index: -2;
+  border: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 94%, var(--filter-accent) 6%);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.03), rgb(255 255 255 / 0.01)),
+    linear-gradient(
+      135deg,
+      color-mix(in srgb, var(--color-surface-card) 95%, var(--filter-accent) 5%),
+      color-mix(
+        in srgb,
+        var(--color-surface-secondary) 97%,
+        var(--filter-accent) 3%
+      )
+    );
+}
+
+.filterButton::after {
+  z-index: -1;
+  opacity: 0;
+  transform: translateX(-18%);
+  background: linear-gradient(
+    115deg,
+    transparent 18%,
+    color-mix(in srgb, white 70%, var(--filter-accent) 30%) 50%,
+    transparent 82%
+  );
+  mix-blend-mode: screen;
+}
+
+.filterButton:hover {
+  color: var(--color-text-primary);
+  opacity: 0.8;
+  transform: translateY(-2px);
+  box-shadow: var(--skill-filter-shadow);
+}
+
+.filterButton:hover::after {
+  opacity: 0.1;
+  transform: translateX(18%);
+}
+
+.filterButton[data-active="true"] {
+  color: var(--color-text-primary);
+  opacity: 1;
+  transform: translateY(-1px);
+  box-shadow: var(--skill-filter-active-shadow);
+}
+
+.filterButton[data-active="true"]::before {
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-subtle) 36%,
+    var(--filter-accent) 64%
+  );
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.12), rgb(255 255 255 / 0.03)),
+    linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-surface-pill) 72%,
+        var(--filter-accent) 28%
+      ),
+      color-mix(
+        in srgb,
+        var(--color-surface-secondary) 76%,
+        var(--filter-accent) 24%
+      )
+    );
+}
+
+.filterButton[data-active="true"]::after {
+  opacity: 0.18;
+  transform: translateX(12%);
+}
+
+.filterButtonDot {
+  position: relative;
+  width: 0.6rem;
+  height: 0.6rem;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--color-text-tertiary) 84%, white 16%);
+  box-shadow:
+    0 0 0 4px rgb(255 255 255 / 0.03),
+    0 0 0 0 rgb(96 165 250 / 0);
+  transition:
+    transform var(--duration-normal) var(--ease-bounce),
+    box-shadow var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out);
+}
+
+.filterButton:hover .filterButtonDot {
+  background: color-mix(in srgb, var(--color-text-secondary) 72%, white 28%);
+}
+
+.filterButton:hover .filterButtonDot,
+.filterButton[data-active="true"] .filterButtonDot {
+  transform: scale(1.15);
+}
+
+.filterButton[data-active="true"] .filterButtonDot {
+  background: color-mix(in srgb, white 18%, var(--filter-accent) 82%);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--filter-accent) 16%, transparent),
+    0 0 18px color-mix(in srgb, var(--filter-accent) 28%, transparent);
+  animation: skill-filter-dot-pulse 2.7s var(--ease-out) infinite;
+}
+
+.filterButtonLabel {
+  position: relative;
+  letter-spacing: 0.01em;
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    letter-spacing var(--duration-normal) var(--ease-out);
+}
+
+.filterButton[data-active="false"] .filterButtonLabel {
+  color: color-mix(in srgb, var(--color-text-secondary) 76%, transparent);
+}
+
+.filterButton:hover .filterButtonLabel,
+.filterButton[data-active="true"] .filterButtonLabel {
+  transform: translateX(1px);
+  letter-spacing: 0.015em;
+}
+
+.skillsGrid {
+  display: flex;
+  min-height: 8.75rem;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  gap: 0.75rem;
+}
+
+.skillChip {
+  --skill-accent: var(--color-skill-neutral);
+  --skill-accent-secondary: var(--skill-accent);
+  --skill-surface-start: color-mix(
+    in srgb,
+    var(--color-bg-inverse) 88%,
+    var(--skill-accent) 12%
+  );
+  --skill-surface-end: color-mix(
+    in srgb,
+    var(--color-bg-inverse) 94%,
+    var(--skill-accent-secondary) 6%
+  );
+  --skill-border-accent: color-mix(
+    in srgb,
+    var(--skill-accent) 60%,
+    var(--skill-accent-secondary) 40%
+  );
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 1.25rem;
+  color: var(--color-text-on-inverse);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  border: 2px solid
+    color-mix(
+      in srgb,
+      var(--color-border-inverse-subtle) 60%,
+      var(--skill-border-accent) 40%
+    );
+  border-radius: var(--radius-sm);
+  background: linear-gradient(
+    135deg,
+    var(--skill-surface-start),
+    var(--skill-surface-end)
+  );
+  box-shadow: var(--skill-chip-shadow);
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+  animation: skill-chip-enter var(--duration-emphasis) var(--ease-out) both;
+  will-change: transform, opacity;
+}
+
+.skillChip:hover {
+  transform: translateY(-3px) scale(1.02);
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-inverse-subtle) 48%,
+    var(--skill-border-accent) 52%
+  );
+  box-shadow: var(--skill-chip-hover-shadow);
+}
+
+.skillChipIcons {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.skillIcon {
+  width: 1rem;
+  height: 1rem;
+  filter: saturate(1.05);
+}
+
+@keyframes skill-chip-enter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--skill-chip-enter-distance)) scale(0.96);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+@keyframes skill-filter-dot-pulse {
+  0%,
+  100% {
+    opacity: 0.92;
+    box-shadow:
+      0 0 0 4px color-mix(in srgb, var(--filter-accent) 14%, transparent),
+      0 0 16px color-mix(in srgb, var(--filter-accent) 22%, transparent);
+  }
+
+  50% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 6px color-mix(in srgb, var(--filter-accent) 18%, transparent),
+      0 0 24px color-mix(in srgb, var(--filter-accent) 32%, transparent);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .filterButton,
+  .skillChip {
+    animation: none;
+    transition-duration: 0ms;
+  }
+
+  .filterButton::before,
+  .filterButton::after,
+  .filterButtonDot,
+  .filterButtonLabel {
+    transition-duration: 0ms;
+    animation: none;
+  }
+
+  .filterButton:hover,
+  .skillChip:hover {
+    transform: none;
+  }
+
+  .filterButton:hover::after,
+  .filterButton[data-active="true"]::after {
+    transform: none;
+  }
+}

--- a/src/sections/Skills.tsx
+++ b/src/sections/Skills.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import Image from "next/image";
+import { useMemo, useState } from "react";
+import { skillCategories, skills, type SkillCategory } from "@/content/skills";
+
+export default function Skills() {
+  const [selected, setSelected] = useState<SkillCategory>("all");
+
+  const filteredSkills = useMemo(() => {
+    if (selected === "all") return skills;
+
+    return skills.filter((skill) => skill.categories.includes(selected));
+  }, [selected]);
+
+  return (
+    <section id="skills" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
+      {/* 타이틀 */}
+      <div className="mb-8 flex items-center gap-4">
+        <div className="h-8 w-1 rounded-full bg-(--color-text-primary)" />
+        <h2 className="text-base font-bold tracking-(--letter-spacing-section) text-(--color-text-primary)">
+          SKILLS
+        </h2>
+      </div>
+      {/* 카테고리 버튼 */}
+      <div className="mb-10 flex flex-wrap gap-3">
+        {skillCategories.map((cat) => {
+          const isActive = selected === cat.value;
+
+          return (
+            <button
+              type="button"
+              key={cat.value}
+              onClick={() => setSelected(cat.value)}
+              className={`cursor-pointer rounded-full px-5 py-2 text-sm font-medium transition-colors duration-200 ${
+                isActive
+                  ? "bg-(--color-surface-pill) text-(--color-text-primary)"
+                  : "bg-(--color-surface-card) text-(--color-text-secondary) hover:bg-(--color-surface-pill-hover) hover:text-(--color-text-primary)"
+              }`}
+            >
+              {cat.label}
+            </button>
+          );
+        })}
+      </div>
+      {/* 스킬 리스트 */}
+      <div className="flex min-h-35 flex-wrap content-start gap-3">
+        {filteredSkills.map((skill) => (
+          <div
+            key={skill.name}
+            className="
+            flex cursor-pointer items-center gap-2 rounded-full border border-(--color-border-subtle)
+            bg-white px-5 py-2 text-sm font-medium text-slate-700 shadow-sm
+            transition-all duration-200
+            hover:scale-[1.03] hover:shadow-md hover:bg-gray-100"
+          >
+            <div className="flex items-center gap-1">
+              {Array.isArray(skill.icon) ? (
+                skill.icon.map((icon) => (
+                  <img
+                    key={icon}
+                    src={`https://cdn.simpleicons.org/${icon}`}
+                    alt={icon}
+                    className="h-4 w-4"
+                  />
+                ))
+              ) : (
+                <img
+                  src={`https://cdn.simpleicons.org/${skill.icon}`}
+                  alt={skill.name}
+                  className="h-4 w-4"
+                />
+              )}
+            </div>
+            {skill.name}
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/sections/Skills.tsx
+++ b/src/sections/Skills.tsx
@@ -2,7 +2,7 @@
 
 import Image from "next/image";
 import { useMemo, useState } from "react";
-import { skillCategories, skills, type SkillCategory } from "@/content/skills";
+import { type SkillCategory, skillCategories, skills } from "@/content/skills";
 
 export default function Skills() {
   const [selected, setSelected] = useState<SkillCategory>("all");

--- a/src/sections/Skills.tsx
+++ b/src/sections/Skills.tsx
@@ -1,8 +1,38 @@
 "use client";
 
-import Image from "next/image";
-import { useMemo, useState } from "react";
-import { type SkillCategory, skillCategories, skills } from "@/content/skills";
+import { type CSSProperties, useMemo, useState } from "react";
+import SectionHeader from "@/components/SectionHeader";
+import SectionLayout from "@/components/SectionLayout";
+import {
+  type SkillAccent,
+  type SkillCategory,
+  skillCategories,
+  skills,
+} from "@/content/skills";
+import styles from "./Skills.module.css";
+
+const fallbackSkillAccent = "var(--color-skill-neutral)";
+
+type SkillChipStyle = CSSProperties & {
+  "--skill-accent": string;
+  "--skill-accent-secondary": string;
+};
+
+function getSkillAccentVar(accent?: SkillAccent) {
+  return accent ? `var(--color-skill-${accent})` : fallbackSkillAccent;
+}
+
+function getSkillChipStyle(
+  accent: SkillAccent,
+  secondaryAccent: SkillAccent | undefined,
+  index: number,
+): SkillChipStyle {
+  return {
+    "--skill-accent": getSkillAccentVar(accent),
+    "--skill-accent-secondary": getSkillAccentVar(secondaryAccent ?? accent),
+    animationDelay: `${index * 45}ms`,
+  };
+}
 
 export default function Skills() {
   const [selected, setSelected] = useState<SkillCategory>("all");
@@ -14,16 +44,10 @@ export default function Skills() {
   }, [selected]);
 
   return (
-    <section id="skills" className="mx-auto max-w-5xl scroll-mt-16 px-6 py-24">
-      {/* 타이틀 */}
-      <div className="mb-8 flex items-center gap-4">
-        <div className="h-8 w-1 rounded-full bg-(--color-text-primary)" />
-        <h2 className="text-base font-bold tracking-(--letter-spacing-section) text-(--color-text-primary)">
-          SKILLS
-        </h2>
-      </div>
-      {/* 카테고리 버튼 */}
-      <div className="mb-10 flex flex-wrap gap-3">
+    <SectionLayout id="skills" className={styles.section}>
+      <SectionHeader title="SKILLS" />
+
+      <div className={styles.filterGroup}>
         {skillCategories.map((cat) => {
           const isActive = selected === cat.value;
 
@@ -32,43 +56,43 @@ export default function Skills() {
               type="button"
               key={cat.value}
               onClick={() => setSelected(cat.value)}
-              className={`cursor-pointer rounded-full px-5 py-2 text-sm font-medium transition-colors duration-200 ${
-                isActive
-                  ? "bg-(--color-surface-pill) text-(--color-text-primary)"
-                  : "bg-(--color-surface-card) text-(--color-text-secondary) hover:bg-(--color-surface-pill-hover) hover:text-(--color-text-primary)"
-              }`}
+              aria-pressed={isActive}
+              data-active={isActive}
+              className={styles.filterButton}
             >
-              {cat.label}
+              <span className={styles.filterButtonDot} aria-hidden="true" />
+              <span className={styles.filterButtonLabel}>{cat.label}</span>
             </button>
           );
         })}
       </div>
-      {/* 스킬 리스트 */}
-      <div className="flex min-h-35 flex-wrap content-start gap-3">
-        {filteredSkills.map((skill) => (
+
+      <div className={styles.skillsGrid}>
+        {filteredSkills.map((skill, index) => (
           <div
-            key={skill.name}
-            className="
-            flex cursor-pointer items-center gap-2 rounded-full border border-(--color-border-subtle)
-            bg-white px-5 py-2 text-sm font-medium text-slate-700 shadow-sm
-            transition-all duration-200
-            hover:scale-[1.03] hover:shadow-md hover:bg-gray-100"
+            key={`${selected}-${skill.name}`}
+            className={styles.skillChip}
+            style={getSkillChipStyle(
+              skill.accent,
+              skill.secondaryAccent,
+              index,
+            )}
           >
-            <div className="flex items-center gap-1">
+            <div className={styles.skillChipIcons}>
               {Array.isArray(skill.icon) ? (
                 skill.icon.map((icon) => (
                   <img
                     key={icon}
                     src={`https://cdn.simpleicons.org/${icon}`}
                     alt={icon}
-                    className="h-4 w-4"
+                    className={styles.skillIcon}
                   />
                 ))
               ) : (
                 <img
                   src={`https://cdn.simpleicons.org/${skill.icon}`}
                   alt={skill.name}
-                  className="h-4 w-4"
+                  className={styles.skillIcon}
                 />
               )}
             </div>
@@ -76,6 +100,6 @@ export default function Skills() {
           </div>
         ))}
       </div>
-    </section>
+    </SectionLayout>
   );
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,6 +1,23 @@
 :root {
   color-scheme: dark;
   --copy-pop-distance: -4px;
+
+  /* skill brand */
+  --color-skill-neutral: #94a3b8;
+  --color-skill-javascript: #f7df1e;
+  --color-skill-typescript: #3178c6;
+  --color-skill-python: #3776ab;
+  --color-skill-c: #a8b9cc;
+  --color-skill-react: #61dafb;
+  --color-skill-nextjs: #111111;
+  --color-skill-html: #e34f26;
+  --color-skill-css: #1572b6;
+  --color-skill-tailwind: #06b6d4;
+  --color-skill-nodejs: #5fa04e;
+  --color-skill-mysql: #4479a1;
+  --color-skill-git: #f05032;
+  --color-skill-figma: #a259ff;
+  --color-skill-docker: #2496ed;
 }
 
 @theme inline {
@@ -23,6 +40,7 @@
   --color-border-subtle: rgb(255 255 255 / 0.1);
   --color-border-strong: rgb(255 255 255 / 0.16);
   --color-border-accent: rgb(96 165 250 / 0.8);
+  --color-border-inverse-subtle: rgb(15 23 42 / 0.08);
 
   /* radius */
   --radius-sm: 12px;


### PR DESCRIPTION
## Vercel 프리뷰 링크
[Preview 바로가기](https://portfolio-git-feat-skills-clean-jang-eunjaes-projects.vercel.app/#skills)

## 작업 UI 스크린샷
<img width="1015" height="347" alt="스크린샷 2026-03-31 오후 9 11 13" src="https://github.com/user-attachments/assets/87892d6e-db01-43f5-bfad-65844a290b00" />

## 작업 내용

메인 페이지에 Skills 섹션을 추가하고, 스킬 데이터와 스타일 구조를 분리해 필터 인터랙션과 기술별 칩 스타일을 정리했습니다.

### Skills 섹션 구현
- `src/app/page.tsx`
- 기존 placeholder 형태의 Skills 영역을 실제 `Skills` 섹션 컴포넌트로 교체했습니다.
- Intro, Profile 이후 자연스럽게 이어지는 섹션 흐름으로 연결했습니다.

### Skills 데이터 및 UI 구성
- `src/content/skills.ts`
- 스킬 카테고리, 스킬 목록, 색상 키를 분리해 데이터 중심으로 관리할 수 있도록 정리했습니다.
- 기술별 아이콘, 카테고리 필터링, HTML/CSS처럼 두 가지 브랜드 컬러를 함께 사용하는 케이스까지 함께 정의했습니다.

### 스타일 / 구조 개선
- `src/sections/Skills.tsx`
- `src/sections/Skills.module.css`
- `src/styles/tokens.css`
- Skills에서만 사용하는 스타일이 많아 전용 스타일을 CSS Module로 분리했습니다.
- 컴포넌트에서는 상태와 렌더링 중심으로만 동작하도록 정리하고, 전역 토큰 파일에는 공통 색상과 브랜드 컬러만 남기도록 구조를 나눴습니다.
- 필터 버튼의 active/inactive 상태 차이, dot 애니메이션, 스킬 칩 hover 및 등장 애니메이션을 함께 정리했습니다.

### 기타 정리
- `.gitignore`
- Codex 로컬 설정 파일이 추적되지 않도록 `.codex/`를 ignore에 추가했습니다.


## 피드백 받고 싶은 내용
1. 스킬 칩에 사용 경험, 관련 프로젝트 같은 보조 정보를 더 넣을지, 지금처럼 기술 스택만 간단하게 보여주는 구성이 더 좋을지 의견이 궁금합니다.

## 관련 이슈
- Closes #3