### PR TITLE
[#4] Experience 섹션 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
+        "lucide-react": "^1.7.0",
         "next": "16.1.6",
         "react": "19.2.3",
         "react-dom": "19.2.3"
@@ -1674,6 +1675,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
+      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "format": "biome format --write"
   },
   "dependencies": {
+    "lucide-react": "^1.7.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,5 @@
 import SectionLayout from "@/components/SectionLayout";
+import Experience from "@/sections/Experience";
 import Intro from "@/sections/Intro";
 import Profile from "@/sections/Profile";
 import Skills from "@/sections/Skills";
@@ -9,9 +10,7 @@ export default function Home() {
       <Intro />
       <Profile />
       <Skills />
-      <SectionLayout id="experience" fullHeight>
-        <h1>Experience</h1>
-      </SectionLayout>
+      <Experience />
       <SectionLayout id="contact" fullHeight>
         <h1>Contact</h1>
       </SectionLayout>

--- a/src/components/SectionFilter.module.css
+++ b/src/components/SectionFilter.module.css
@@ -1,0 +1,287 @@
+.group {
+  --section-filter-accent: var(--color-border-accent);
+  --section-filter-group-shadow: 0 22px 48px rgb(2 8 23 / 0.18);
+  --section-filter-shadow: 0 10px 24px rgb(2 8 23 / 0.14);
+  --section-filter-active-shadow: 0 16px 32px rgb(2 8 23 / 0.22);
+  --section-filter-active-before-shadow: none;
+  --section-filter-button-padding-x: 1.25rem;
+  --section-filter-dot-base-glow: rgb(96 165 250 / 0);
+  display: inline-flex;
+  min-inline-size: 0;
+  max-width: 100%;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+  padding: 0.5rem;
+  border: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 88%, white 12%);
+  border-radius: calc(var(--radius-full) + 6px);
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.01)),
+    linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-surface-card) 84%,
+        var(--color-surface-pill) 16%
+      ),
+      color-mix(in srgb, var(--color-surface-secondary) 88%, black 12%)
+    );
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.05),
+    var(--section-filter-group-shadow);
+}
+
+.legend {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  white-space: nowrap;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.group[data-layout="wrap"] {
+  width: fit-content;
+  flex-wrap: wrap;
+}
+
+.group[data-layout="scroll"] {
+  display: flex;
+  width: min(100%, max-content);
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.group[data-layout="scroll"]::-webkit-scrollbar {
+  display: none;
+}
+
+.button {
+  position: relative;
+  isolation: isolate;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex: 0 0 auto;
+  overflow: hidden;
+  padding: 0.5rem var(--section-filter-button-padding-x);
+  color: var(--color-text-secondary);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+  border-radius: var(--radius-full);
+  background: transparent;
+  opacity: 0.54;
+  box-shadow: none;
+  transition:
+    color var(--duration-normal) var(--ease-out),
+    opacity var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out);
+}
+
+.button::before,
+.button::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  transition:
+    opacity var(--duration-normal) var(--ease-out),
+    transform var(--duration-emphasis) var(--ease-out);
+}
+
+.button::before {
+  z-index: -2;
+  border: 1px solid
+    color-mix(
+      in srgb,
+      var(--color-border-subtle) 94%,
+      var(--section-filter-accent) 6%
+    );
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.03), rgb(255 255 255 / 0.01)),
+    linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-surface-card) 95%,
+        var(--section-filter-accent) 5%
+      ),
+      color-mix(
+        in srgb,
+        var(--color-surface-secondary) 97%,
+        var(--section-filter-accent) 3%
+      )
+    );
+}
+
+.button::after {
+  z-index: -1;
+  opacity: 0;
+  transform: translateX(-18%);
+  background: linear-gradient(
+    115deg,
+    transparent 18%,
+    color-mix(in srgb, white 70%, var(--section-filter-accent) 30%) 50%,
+    transparent 82%
+  );
+  mix-blend-mode: screen;
+}
+
+.button:hover {
+  color: var(--color-text-primary);
+  opacity: 0.8;
+  transform: translateY(-2px);
+  box-shadow: var(--section-filter-shadow);
+}
+
+.button:hover::after {
+  opacity: 0.1;
+  transform: translateX(18%);
+}
+
+.button[data-active="true"] {
+  color: var(--color-text-primary);
+  opacity: 1;
+  transform: translateY(-1px);
+  box-shadow: var(--section-filter-active-shadow);
+}
+
+.button[data-active="true"]::before {
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-subtle) 36%,
+    var(--section-filter-accent) 64%
+  );
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.12), rgb(255 255 255 / 0.03)),
+    linear-gradient(
+      135deg,
+      color-mix(
+        in srgb,
+        var(--color-surface-pill) 72%,
+        var(--section-filter-accent) 28%
+      ),
+      color-mix(
+        in srgb,
+        var(--color-surface-secondary) 76%,
+        var(--section-filter-accent) 24%
+      )
+    );
+  box-shadow: var(--section-filter-active-before-shadow);
+}
+
+.button[data-active="true"]::after {
+  opacity: 0.18;
+  transform: translateX(12%);
+}
+
+.dot {
+  position: relative;
+  width: 0.6rem;
+  height: 0.6rem;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--color-text-tertiary) 84%, white 16%);
+  box-shadow:
+    0 0 0 4px rgb(255 255 255 / 0.03),
+    0 0 0 0 var(--section-filter-dot-base-glow);
+  transition:
+    transform var(--duration-normal) var(--ease-bounce),
+    box-shadow var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out);
+}
+
+.button:hover .dot {
+  background: color-mix(in srgb, var(--color-text-secondary) 72%, white 28%);
+}
+
+.button:hover .dot,
+.button[data-active="true"] .dot {
+  transform: scale(1.15);
+}
+
+.button[data-active="true"] .dot {
+  background: color-mix(in srgb, white 18%, var(--section-filter-accent) 82%);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--section-filter-accent) 16%, transparent),
+    0 0 18px color-mix(in srgb, var(--section-filter-accent) 28%, transparent);
+  animation: section-filter-dot-pulse 2.7s var(--ease-out) infinite;
+}
+
+.label {
+  position: relative;
+  letter-spacing: 0.01em;
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    letter-spacing var(--duration-normal) var(--ease-out);
+}
+
+.button[data-active="false"] .label {
+  color: color-mix(in srgb, var(--color-text-secondary) 76%, transparent);
+}
+
+.button:hover .label,
+.button[data-active="true"] .label {
+  transform: translateX(1px);
+  letter-spacing: 0.015em;
+}
+
+@keyframes section-filter-dot-pulse {
+  0%,
+  100% {
+    opacity: 0.92;
+    box-shadow:
+      0 0 0 4px
+      color-mix(in srgb, var(--section-filter-accent) 14%, transparent),
+      0 0 16px color-mix(in srgb, var(--section-filter-accent) 22%, transparent);
+  }
+
+  50% {
+    opacity: 1;
+    box-shadow:
+      0 0 0 6px
+      color-mix(in srgb, var(--section-filter-accent) 18%, transparent),
+      0 0 24px color-mix(in srgb, var(--section-filter-accent) 32%, transparent);
+  }
+}
+
+@media (width <= 768px) {
+  .button {
+    justify-content: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .button {
+    animation: none;
+    transition-duration: 0ms;
+  }
+
+  .button::before,
+  .button::after,
+  .dot,
+  .label {
+    transition-duration: 0ms;
+    animation: none;
+  }
+
+  .button:hover {
+    transform: none;
+  }
+
+  .button:hover::after,
+  .button[data-active="true"]::after {
+    transform: none;
+  }
+}

--- a/src/components/SectionFilter.tsx
+++ b/src/components/SectionFilter.tsx
@@ -1,0 +1,45 @@
+import styles from "./SectionFilter.module.css";
+
+export interface SectionFilterOption<Value extends string> {
+  label: string;
+  value: Value;
+}
+
+type SectionFilterProps<Value extends string> = {
+  ariaLabel: string;
+  options: readonly SectionFilterOption<Value>[];
+  selected: Value;
+  onChange: (value: Value) => void;
+  layout?: "wrap" | "scroll";
+};
+
+export default function SectionFilter<Value extends string>({
+  ariaLabel,
+  options,
+  selected,
+  onChange,
+  layout = "wrap",
+}: SectionFilterProps<Value>) {
+  return (
+    <fieldset className={styles.group} data-layout={layout}>
+      <legend className={styles.legend}>{ariaLabel}</legend>
+      {options.map((option) => {
+        const isActive = selected === option.value;
+
+        return (
+          <button
+            type="button"
+            key={option.value}
+            onClick={() => onChange(option.value)}
+            aria-pressed={isActive}
+            data-active={isActive}
+            className={styles.button}
+          >
+            <span className={styles.dot} aria-hidden="true" />
+            <span className={styles.label}>{option.label}</span>
+          </button>
+        );
+      })}
+    </fieldset>
+  );
+}

--- a/src/content/experience.ts
+++ b/src/content/experience.ts
@@ -1,0 +1,98 @@
+export type ExperienceCategory = "all" | "project" | "activity" | "study";
+
+export type ExperiencePrimaryCategory = Exclude<ExperienceCategory, "all">;
+
+export type ExperienceIcon =
+  | "rocket"
+  | "trophy"
+  | "terminal"
+  | "users"
+  | "graduation"
+  | "sparkles";
+
+export interface ExperienceCategoryOption {
+  label: string;
+  value: ExperienceCategory;
+}
+
+export interface ExperienceItem {
+  title: string;
+  period: string;
+  description: string;
+  category: ExperiencePrimaryCategory;
+  tags?: string[];
+  icon: ExperienceIcon;
+}
+
+export const experienceCategories: ExperienceCategoryOption[] = [
+  { label: "All", value: "all" },
+  { label: "Project", value: "project" },
+  { label: "Activity", value: "activity" },
+  { label: "Study", value: "study" },
+];
+
+export const experienceCategoryLabels: Record<
+  ExperiencePrimaryCategory,
+  string
+> = {
+  project: "Project",
+  activity: "Activity",
+  study: "Study",
+};
+
+export const experiences: ExperienceItem[] = [
+  {
+    title: "서비스 프로젝트",
+    period: "2023 - Present",
+    description:
+      "기획부터 개발, 배포까지 참여하며 사용자 흐름을 개선하는 웹 서비스를 제작했습니다.",
+    category: "project",
+    tags: ["Team", "Club"],
+    icon: "rocket",
+  },
+  {
+    title: "해커톤 수상",
+    period: "2024",
+    description:
+      "짧은 기간 안에 팀 프로젝트를 완성하고 발표하며 우수한 성과를 거두었습니다.",
+    category: "project",
+    tags: ["Award", "Team"],
+    icon: "trophy",
+  },
+  {
+    title: "알고리즘 스터디",
+    period: "2023 - 2024",
+    description:
+      "문제 풀이와 코드 리뷰를 중심으로 스터디를 운영하며 꾸준한 학습 루틴을 만들었습니다.",
+    category: "study",
+    tags: ["Algorithm"],
+    icon: "terminal",
+  },
+  {
+    title: "개발 동아리 활동",
+    period: "2022 - Present",
+    description:
+      "협업 프로젝트를 진행하며 프론트엔드 개발과 커뮤니케이션 경험을 함께 쌓았습니다.",
+    category: "activity",
+    tags: ["Club", "Leadership"],
+    icon: "users",
+  },
+  {
+    title: "웹 개발 부트캠프",
+    period: "2024",
+    description:
+      "실무형 커리큘럼을 통해 서비스 구현, 협업 프로세스, 배포 경험을 집중적으로 학습했습니다.",
+    category: "study",
+    tags: ["Bootcamp"],
+    icon: "graduation",
+  },
+  {
+    title: "MVP 사이드 프로젝트",
+    period: "2024",
+    description:
+      "아이디어를 빠르게 제품으로 옮기는 과정을 경험하며 기능 우선순위와 구현 속도를 다듬었습니다.",
+    category: "project",
+    tags: ["Personal"],
+    icon: "sparkles",
+  },
+];

--- a/src/sections/Experience.module.css
+++ b/src/sections/Experience.module.css
@@ -40,6 +40,7 @@
       var(--experience-accent) 16%
     );
   border-radius: 2rem;
+  cursor: default;
   background:
     linear-gradient(180deg, rgb(255 255 255 / 0.03), rgb(255 255 255 / 0.01)),
     linear-gradient(
@@ -50,6 +51,7 @@
   box-shadow: var(--experience-card-shadow);
   animation: experience-card-enter var(--duration-emphasis) var(--ease-out) both;
   overflow: hidden;
+  user-select: none;
   transition:
     transform var(--duration-normal) var(--ease-out),
     border-color var(--duration-normal) var(--ease-out),
@@ -238,6 +240,30 @@
   box-shadow: 0 10px 18px rgb(15 23 42 / 0.12);
 }
 
+.cardLink {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.8rem;
+  margin-left: auto;
+  color: color-mix(
+    in srgb,
+    var(--experience-accent-soft) 68%,
+    var(--experience-accent) 32%
+  );
+  opacity: 0.88;
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out),
+    opacity var(--duration-normal) var(--ease-out);
+}
+
+.cardLinkArrow {
+  width: 1.15rem;
+  height: 1.15rem;
+  transition: transform var(--duration-normal) var(--ease-out);
+}
+
 .card:hover .categoryBadge {
   color: color-mix(in srgb, var(--experience-accent) 82%, white 18%);
   letter-spacing: 0.105em;
@@ -263,6 +289,16 @@
 .card:hover .iconGlyph {
   transform: rotate(5deg) scale(1.03);
   color: color-mix(in srgb, var(--experience-accent-soft) 46%, white 54%);
+}
+
+.card:hover .cardLink {
+  transform: translateX(1px) translateY(-1px);
+  color: color-mix(in srgb, var(--experience-accent-soft) 52%, white 48%);
+  opacity: 1;
+}
+
+.card:hover .cardLinkArrow {
+  transform: translateX(2px) translateY(-1px);
 }
 
 @keyframes experience-card-enter {
@@ -313,7 +349,9 @@
   .card::before,
   .iconTile,
   .iconGlyph,
-  .categoryBadge {
+  .categoryBadge,
+  .cardLink,
+  .cardLinkArrow {
     animation: none;
     transition-duration: 0ms;
   }

--- a/src/sections/Experience.module.css
+++ b/src/sections/Experience.module.css
@@ -1,0 +1,320 @@
+.section {
+  --experience-accent: #97a0ff;
+  --experience-accent-soft: #8ea6d8;
+  --section-filter-accent: color-mix(
+    in srgb,
+    var(--experience-accent) 58%,
+    var(--experience-accent-soft) 42%
+  );
+  --section-filter-group-shadow: 0 22px 48px rgb(2 8 23 / 0.18);
+  --section-filter-shadow: 0 10px 24px rgb(2 8 23 / 0.14);
+  --section-filter-active-shadow: 0 16px 32px rgb(2 8 23 / 0.2);
+  --section-filter-active-before-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.08), 0 12px 24px
+    color-mix(in srgb, var(--section-filter-accent) 14%, transparent);
+  --section-filter-button-padding-x: 1.2rem;
+  --section-filter-dot-base-glow: rgb(20 217 245 / 0);
+  --experience-card-shadow: 0 16px 34px rgb(15 23 42 / 0.16);
+  --experience-card-hover-shadow: 0 34px 58px rgb(15 23 42 / 0.28);
+  --experience-enter-distance: 16px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1.25rem;
+}
+
+.card {
+  position: relative;
+  isolation: isolate;
+  display: flex;
+  min-height: 20.75rem;
+  flex-direction: column;
+  gap: 1.2rem;
+  padding: 1.5rem;
+  border: 2px solid
+    color-mix(
+      in srgb,
+      var(--color-border-subtle) 84%,
+      var(--experience-accent) 16%
+    );
+  border-radius: 2rem;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.03), rgb(255 255 255 / 0.01)),
+    linear-gradient(
+      160deg,
+      color-mix(in srgb, var(--color-surface-card) 92%, white 8%),
+      color-mix(in srgb, var(--color-surface-secondary) 94%, black 6%)
+    );
+  box-shadow: var(--experience-card-shadow);
+  animation: experience-card-enter var(--duration-emphasis) var(--ease-out) both;
+  overflow: hidden;
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.05), rgb(255 255 255 / 0.015)),
+    linear-gradient(
+      145deg,
+      color-mix(in srgb, var(--experience-accent) 9%, transparent),
+      color-mix(in srgb, white 4%, transparent) 42%,
+      transparent 78%
+    );
+  transition: opacity var(--duration-normal) var(--ease-out);
+}
+
+.card > * {
+  position: relative;
+  z-index: 1;
+}
+
+.card:hover {
+  transform: translateY(-8px) scale(1.016);
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-subtle) 54%,
+    var(--experience-accent) 46%
+  );
+  box-shadow: var(--experience-card-hover-shadow);
+}
+
+.card:hover::before {
+  opacity: 1;
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.cardMetaCopy {
+  display: grid;
+  gap: 0.6rem;
+  padding-top: 0.2rem;
+}
+
+.iconTile {
+  display: grid;
+  width: 4rem;
+  height: 4rem;
+  place-items: center;
+  border-radius: 1.25rem;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.02)),
+    linear-gradient(
+      180deg,
+      color-mix(
+        in srgb,
+        var(--experience-accent) 20%,
+        var(--color-surface-secondary) 80%
+      ),
+      color-mix(
+        in srgb,
+        var(--experience-accent-soft) 14%,
+        var(--color-surface-card) 86%
+      )
+    );
+  transition:
+    transform var(--duration-normal) var(--ease-bounce),
+    box-shadow var(--duration-normal) var(--ease-out),
+    background var(--duration-normal) var(--ease-out);
+}
+
+.categoryBadge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  color: color-mix(in srgb, var(--experience-accent) 68%, white 32%);
+  font-size: 0.76rem;
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  transition:
+    color var(--duration-normal) var(--ease-out),
+    text-shadow var(--duration-normal) var(--ease-out),
+    transform var(--duration-normal) var(--ease-out),
+    letter-spacing var(--duration-normal) var(--ease-out);
+}
+
+.categoryBadge::before {
+  content: "";
+  width: 0.4rem;
+  height: 0.4rem;
+  border-radius: 9999px;
+  background: color-mix(in srgb, var(--experience-accent) 74%, white 26%);
+  box-shadow: 0 0 12px
+    color-mix(in srgb, var(--experience-accent) 22%, transparent);
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out);
+}
+
+.iconGlyph {
+  width: 1.55rem;
+  height: 1.55rem;
+  color: color-mix(
+    in srgb,
+    var(--experience-accent-soft) 56%,
+    var(--experience-accent) 44%
+  );
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out);
+}
+
+.cardBody {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.cardTitle {
+  font-size: clamp(1.425rem, 1.85vw, 1.875rem);
+  line-height: 1.15;
+  font-weight: 800;
+  color: var(--color-text-primary);
+}
+
+.cardPeriod {
+  color: color-mix(in srgb, var(--color-text-tertiary) 88%, white 12%);
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
+.cardDescription {
+  color: color-mix(in srgb, var(--color-text-secondary) 90%, white 10%);
+  font-size: 0.95rem;
+  line-height: 1.65;
+}
+
+.tagGroup {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: auto;
+}
+
+.tag {
+  padding: 0.32rem 0.62rem;
+  color: color-mix(in srgb, var(--color-text-secondary) 64%, white 36%);
+  font-size: 0.74rem;
+  line-height: 1.2;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  border: 1px solid
+    color-mix(in srgb, var(--color-border-subtle) 90%, white 10%);
+  border-radius: var(--radius-sm);
+  background: color-mix(in srgb, var(--color-surface-pill) 66%, black 34%);
+  transition:
+    transform var(--duration-normal) var(--ease-out),
+    border-color var(--duration-normal) var(--ease-out),
+    background-color var(--duration-normal) var(--ease-out),
+    color var(--duration-normal) var(--ease-out),
+    box-shadow var(--duration-normal) var(--ease-out);
+}
+
+.tag:hover {
+  transform: translateY(-1px) scale(1.04);
+  color: color-mix(in srgb, var(--color-text-secondary) 52%, white 48%);
+  border-color: color-mix(
+    in srgb,
+    var(--color-border-subtle) 58%,
+    var(--experience-accent) 42%
+  );
+  background: color-mix(in srgb, var(--color-surface-pill) 56%, black 44%);
+  box-shadow: 0 10px 18px rgb(15 23 42 / 0.12);
+}
+
+.card:hover .categoryBadge {
+  color: color-mix(in srgb, var(--experience-accent) 82%, white 18%);
+  letter-spacing: 0.105em;
+  text-shadow: 0 0 14px
+    color-mix(in srgb, var(--experience-accent) 14%, transparent);
+  transform: translateX(1px);
+}
+
+.card:hover .categoryBadge::before {
+  transform: scale(1.16);
+  background: color-mix(in srgb, var(--experience-accent) 82%, white 18%);
+  box-shadow:
+    0 0 0 4px color-mix(in srgb, var(--experience-accent) 12%, transparent),
+    0 0 18px color-mix(in srgb, var(--experience-accent) 28%, transparent);
+  animation: experience-category-badge-pulse 2.4s var(--ease-out) infinite;
+}
+
+.card:hover .iconTile {
+  transform: translateY(-2px) rotate(-4deg) scale(1.02);
+  box-shadow: 0 16px 28px rgb(15 23 42 / 0.18);
+}
+
+.card:hover .iconGlyph {
+  transform: rotate(5deg) scale(1.03);
+  color: color-mix(in srgb, var(--experience-accent-soft) 46%, white 54%);
+}
+
+@keyframes experience-card-enter {
+  from {
+    opacity: 0;
+    transform: translateY(var(--experience-enter-distance));
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes experience-category-badge-pulse {
+  0%,
+  100% {
+    box-shadow:
+      0 0 0 4px color-mix(in srgb, var(--experience-accent) 10%, transparent),
+      0 0 16px color-mix(in srgb, var(--experience-accent) 24%, transparent);
+  }
+
+  50% {
+    box-shadow:
+      0 0 0 5px color-mix(in srgb, var(--experience-accent) 14%, transparent),
+      0 0 24px color-mix(in srgb, var(--experience-accent) 34%, transparent);
+  }
+}
+
+@media (width <= 1024px) {
+  .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (width <= 768px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .card {
+    min-height: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .card,
+  .card::before,
+  .iconTile,
+  .iconGlyph,
+  .categoryBadge {
+    animation: none;
+    transition-duration: 0ms;
+  }
+}

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import {
+  CodeXml,
+  GraduationCap,
+  type LucideIcon,
+  Rocket,
+  Sparkles,
+  Trophy,
+  Users,
+} from "lucide-react";
+import { useState } from "react";
+import SectionFilter from "@/components/SectionFilter";
+import SectionHeader from "@/components/SectionHeader";
+import SectionLayout from "@/components/SectionLayout";
+import {
+  type ExperienceCategory,
+  type ExperienceIcon,
+  experienceCategories,
+  experienceCategoryLabels,
+  experiences,
+} from "@/content/experience";
+import styles from "./Experience.module.css";
+
+const experienceIconMap: Record<ExperienceIcon, LucideIcon> = {
+  rocket: Rocket,
+  trophy: Trophy,
+  terminal: CodeXml,
+  users: Users,
+  graduation: GraduationCap,
+  sparkles: Sparkles,
+};
+
+function ExperienceIconGlyph({
+  icon,
+  className,
+}: {
+  icon: ExperienceIcon;
+  className?: string;
+}) {
+  const Icon = experienceIconMap[icon];
+
+  return <Icon className={className} aria-hidden="true" />;
+}
+
+export default function Experience() {
+  const [selected, setSelected] = useState<ExperienceCategory>("all");
+  const filteredExperiences =
+    selected === "all"
+      ? experiences
+      : experiences.filter((item) => item.category === selected);
+
+  return (
+    <SectionLayout id="experience" className={styles.section}>
+      <SectionHeader title="EXPERIENCE" />
+
+      <SectionFilter
+        ariaLabel="Filter experiences by category"
+        options={experienceCategories}
+        selected={selected}
+        onChange={setSelected}
+        layout="scroll"
+      />
+
+      <div className={styles.grid}>
+        {filteredExperiences.map((item, index) => (
+          <article
+            key={`${selected}-${item.title}`}
+            className={styles.card}
+            style={{ animationDelay: `${index * 70}ms` }}
+          >
+            <div className={styles.cardMeta}>
+              <div className={styles.iconTile}>
+                <ExperienceIconGlyph
+                  icon={item.icon}
+                  className={styles.iconGlyph}
+                />
+              </div>
+              <div className={styles.cardMetaCopy}>
+                <span className={styles.categoryBadge}>
+                  {experienceCategoryLabels[item.category]}
+                </span>
+                <p className={styles.cardPeriod}>{item.period}</p>
+              </div>
+            </div>
+
+            <div className={styles.cardBody}>
+              <h3 className={styles.cardTitle}>{item.title}</h3>
+              <p className={styles.cardDescription}>{item.description}</p>
+            </div>
+
+            {item.tags?.length ? (
+              <div className={styles.tagGroup}>
+                {item.tags.map((tag) => (
+                  <span key={`${item.title}-${tag}`} className={styles.tag}>
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </SectionLayout>
+  );
+}

--- a/src/sections/Experience.tsx
+++ b/src/sections/Experience.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  ArrowUpRight,
   CodeXml,
   GraduationCap,
   type LucideIcon,
@@ -98,6 +99,10 @@ export default function Experience() {
                 ))}
               </div>
             ) : null}
+
+            <div className={styles.cardLink} aria-hidden="true">
+              <ArrowUpRight className={styles.cardLinkArrow} />
+            </div>
           </article>
         ))}
       </div>

--- a/src/sections/Skills.module.css
+++ b/src/sections/Skills.module.css
@@ -1,204 +1,10 @@
 .section {
-  --skill-filter-group-shadow: 0 22px 48px rgb(2 8 23 / 0.18);
-  --skill-filter-shadow: 0 10px 24px rgb(2 8 23 / 0.14);
-  --skill-filter-active-shadow: 0 16px 32px rgb(2 8 23 / 0.22);
+  --section-filter-group-shadow: 0 22px 48px rgb(2 8 23 / 0.18);
+  --section-filter-shadow: 0 10px 24px rgb(2 8 23 / 0.14);
+  --section-filter-active-shadow: 0 16px 32px rgb(2 8 23 / 0.22);
   --skill-chip-shadow: 0 10px 24px rgb(15 23 42 / 0.08);
   --skill-chip-hover-shadow: 0 18px 32px rgb(15 23 42 / 0.14);
   --skill-chip-enter-distance: 14px;
-}
-
-.filterGroup {
-  display: inline-flex;
-  width: fit-content;
-  max-width: 100%;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 2.5rem;
-  padding: 0.5rem;
-  border: 1px solid
-    color-mix(in srgb, var(--color-border-subtle) 88%, white 12%);
-  border-radius: calc(var(--radius-full) + 6px);
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.04), rgb(255 255 255 / 0.01)),
-    linear-gradient(
-      135deg,
-      color-mix(
-        in srgb,
-        var(--color-surface-card) 84%,
-        var(--color-surface-pill) 16%
-      ),
-      color-mix(in srgb, var(--color-surface-secondary) 88%, black 12%)
-    );
-  box-shadow:
-    inset 0 1px 0 rgb(255 255 255 / 0.05),
-    var(--skill-filter-group-shadow);
-}
-
-.filterButton {
-  --filter-accent: var(--color-border-accent);
-  position: relative;
-  isolation: isolate;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  overflow: hidden;
-  padding: 0.5rem 1.25rem;
-  color: var(--color-text-secondary);
-  font-size: 0.875rem;
-  line-height: 1.25rem;
-  font-weight: 500;
-  cursor: pointer;
-  border: 1px solid transparent;
-  border-radius: var(--radius-full);
-  background: transparent;
-  opacity: 0.54;
-  box-shadow: none;
-  transition:
-    color var(--duration-normal) var(--ease-out),
-    opacity var(--duration-normal) var(--ease-out),
-    background-color var(--duration-normal) var(--ease-out),
-    border-color var(--duration-normal) var(--ease-out),
-    box-shadow var(--duration-normal) var(--ease-out),
-    transform var(--duration-normal) var(--ease-out);
-}
-
-.filterButton::before,
-.filterButton::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: inherit;
-  transition:
-    opacity var(--duration-normal) var(--ease-out),
-    transform var(--duration-emphasis) var(--ease-out);
-}
-
-.filterButton::before {
-  z-index: -2;
-  border: 1px solid
-    color-mix(in srgb, var(--color-border-subtle) 94%, var(--filter-accent) 6%);
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.03), rgb(255 255 255 / 0.01)),
-    linear-gradient(
-      135deg,
-      color-mix(in srgb, var(--color-surface-card) 95%, var(--filter-accent) 5%),
-      color-mix(
-        in srgb,
-        var(--color-surface-secondary) 97%,
-        var(--filter-accent) 3%
-      )
-    );
-}
-
-.filterButton::after {
-  z-index: -1;
-  opacity: 0;
-  transform: translateX(-18%);
-  background: linear-gradient(
-    115deg,
-    transparent 18%,
-    color-mix(in srgb, white 70%, var(--filter-accent) 30%) 50%,
-    transparent 82%
-  );
-  mix-blend-mode: screen;
-}
-
-.filterButton:hover {
-  color: var(--color-text-primary);
-  opacity: 0.8;
-  transform: translateY(-2px);
-  box-shadow: var(--skill-filter-shadow);
-}
-
-.filterButton:hover::after {
-  opacity: 0.1;
-  transform: translateX(18%);
-}
-
-.filterButton[data-active="true"] {
-  color: var(--color-text-primary);
-  opacity: 1;
-  transform: translateY(-1px);
-  box-shadow: var(--skill-filter-active-shadow);
-}
-
-.filterButton[data-active="true"]::before {
-  border-color: color-mix(
-    in srgb,
-    var(--color-border-subtle) 36%,
-    var(--filter-accent) 64%
-  );
-  background:
-    linear-gradient(180deg, rgb(255 255 255 / 0.12), rgb(255 255 255 / 0.03)),
-    linear-gradient(
-      135deg,
-      color-mix(
-        in srgb,
-        var(--color-surface-pill) 72%,
-        var(--filter-accent) 28%
-      ),
-      color-mix(
-        in srgb,
-        var(--color-surface-secondary) 76%,
-        var(--filter-accent) 24%
-      )
-    );
-}
-
-.filterButton[data-active="true"]::after {
-  opacity: 0.18;
-  transform: translateX(12%);
-}
-
-.filterButtonDot {
-  position: relative;
-  width: 0.6rem;
-  height: 0.6rem;
-  flex-shrink: 0;
-  border-radius: 9999px;
-  background: color-mix(in srgb, var(--color-text-tertiary) 84%, white 16%);
-  box-shadow:
-    0 0 0 4px rgb(255 255 255 / 0.03),
-    0 0 0 0 rgb(96 165 250 / 0);
-  transition:
-    transform var(--duration-normal) var(--ease-bounce),
-    box-shadow var(--duration-normal) var(--ease-out),
-    background-color var(--duration-normal) var(--ease-out);
-}
-
-.filterButton:hover .filterButtonDot {
-  background: color-mix(in srgb, var(--color-text-secondary) 72%, white 28%);
-}
-
-.filterButton:hover .filterButtonDot,
-.filterButton[data-active="true"] .filterButtonDot {
-  transform: scale(1.15);
-}
-
-.filterButton[data-active="true"] .filterButtonDot {
-  background: color-mix(in srgb, white 18%, var(--filter-accent) 82%);
-  box-shadow:
-    0 0 0 4px color-mix(in srgb, var(--filter-accent) 16%, transparent),
-    0 0 18px color-mix(in srgb, var(--filter-accent) 28%, transparent);
-  animation: skill-filter-dot-pulse 2.7s var(--ease-out) infinite;
-}
-
-.filterButtonLabel {
-  position: relative;
-  letter-spacing: 0.01em;
-  transition:
-    transform var(--duration-normal) var(--ease-out),
-    letter-spacing var(--duration-normal) var(--ease-out);
-}
-
-.filterButton[data-active="false"] .filterButtonLabel {
-  color: color-mix(in srgb, var(--color-text-secondary) 76%, transparent);
-}
-
-.filterButton:hover .filterButtonLabel,
-.filterButton[data-active="true"] .filterButtonLabel {
-  transform: translateX(1px);
-  letter-spacing: 0.015em;
 }
 
 .skillsGrid {
@@ -278,6 +84,17 @@
   filter: saturate(1.05);
 }
 
+@media (prefers-reduced-motion: reduce) {
+  .skillChip {
+    animation: none;
+    transition-duration: 0ms;
+  }
+
+  .skillChip:hover {
+    transform: none;
+  }
+}
+
 @keyframes skill-chip-enter {
   from {
     opacity: 0;
@@ -287,48 +104,5 @@
   to {
     opacity: 1;
     transform: translateY(0) scale(1);
-  }
-}
-
-@keyframes skill-filter-dot-pulse {
-  0%,
-  100% {
-    opacity: 0.92;
-    box-shadow:
-      0 0 0 4px color-mix(in srgb, var(--filter-accent) 14%, transparent),
-      0 0 16px color-mix(in srgb, var(--filter-accent) 22%, transparent);
-  }
-
-  50% {
-    opacity: 1;
-    box-shadow:
-      0 0 0 6px color-mix(in srgb, var(--filter-accent) 18%, transparent),
-      0 0 24px color-mix(in srgb, var(--filter-accent) 32%, transparent);
-  }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .filterButton,
-  .skillChip {
-    animation: none;
-    transition-duration: 0ms;
-  }
-
-  .filterButton::before,
-  .filterButton::after,
-  .filterButtonDot,
-  .filterButtonLabel {
-    transition-duration: 0ms;
-    animation: none;
-  }
-
-  .filterButton:hover,
-  .skillChip:hover {
-    transform: none;
-  }
-
-  .filterButton:hover::after,
-  .filterButton[data-active="true"]::after {
-    transform: none;
   }
 }

--- a/src/sections/Skills.tsx
+++ b/src/sections/Skills.tsx
@@ -1,11 +1,13 @@
 "use client";
 
-import { type CSSProperties, useMemo, useState } from "react";
+import { type CSSProperties, useState } from "react";
+import SectionFilter from "@/components/SectionFilter";
 import SectionHeader from "@/components/SectionHeader";
 import SectionLayout from "@/components/SectionLayout";
 import {
   type SkillAccent,
   type SkillCategory,
+  type SkillItem,
   skillCategories,
   skills,
 } from "@/content/skills";
@@ -34,38 +36,44 @@ function getSkillChipStyle(
   };
 }
 
+function getSkillIconSrc(icon: string) {
+  return `https://cdn.simpleicons.org/${icon}`;
+}
+
+function SkillIcons({ icon, name }: Pick<SkillItem, "icon" | "name">) {
+  const icons = Array.isArray(icon) ? icon : [icon];
+
+  return icons.map((iconName) => (
+    // biome-ignore lint/performance/noImgElement: Simple Icons SVGs are tiny decorative CDN assets, so raw img is the simpler fit here.
+    <img
+      key={`${name}-${iconName}`}
+      src={getSkillIconSrc(iconName)}
+      alt=""
+      aria-hidden="true"
+      className={styles.skillIcon}
+      loading="lazy"
+      decoding="async"
+    />
+  ));
+}
+
 export default function Skills() {
   const [selected, setSelected] = useState<SkillCategory>("all");
-
-  const filteredSkills = useMemo(() => {
-    if (selected === "all") return skills;
-
-    return skills.filter((skill) => skill.categories.includes(selected));
-  }, [selected]);
+  const filteredSkills =
+    selected === "all"
+      ? skills
+      : skills.filter((skill) => skill.categories.includes(selected));
 
   return (
     <SectionLayout id="skills" className={styles.section}>
       <SectionHeader title="SKILLS" />
 
-      <div className={styles.filterGroup}>
-        {skillCategories.map((cat) => {
-          const isActive = selected === cat.value;
-
-          return (
-            <button
-              type="button"
-              key={cat.value}
-              onClick={() => setSelected(cat.value)}
-              aria-pressed={isActive}
-              data-active={isActive}
-              className={styles.filterButton}
-            >
-              <span className={styles.filterButtonDot} aria-hidden="true" />
-              <span className={styles.filterButtonLabel}>{cat.label}</span>
-            </button>
-          );
-        })}
-      </div>
+      <SectionFilter
+        ariaLabel="Filter skills by category"
+        options={skillCategories}
+        selected={selected}
+        onChange={setSelected}
+      />
 
       <div className={styles.skillsGrid}>
         {filteredSkills.map((skill, index) => (
@@ -79,22 +87,7 @@ export default function Skills() {
             )}
           >
             <div className={styles.skillChipIcons}>
-              {Array.isArray(skill.icon) ? (
-                skill.icon.map((icon) => (
-                  <img
-                    key={icon}
-                    src={`https://cdn.simpleicons.org/${icon}`}
-                    alt={icon}
-                    className={styles.skillIcon}
-                  />
-                ))
-              ) : (
-                <img
-                  src={`https://cdn.simpleicons.org/${skill.icon}`}
-                  alt={skill.name}
-                  className={styles.skillIcon}
-                />
-              )}
+              <SkillIcons icon={skill.icon} name={skill.name} />
             </div>
             {skill.name}
           </div>


### PR DESCRIPTION
## Vercel 프리뷰 링크
[Preview 바로가기](https://portfolio-git-feat-experience-jang-eunjaes-projects.vercel.app/)

## 작업 UI 스크린샷
<img width="1061" height="522" alt="스크린샷 2026-04-01 오후 9 59 27" src="https://github.com/user-attachments/assets/0b179c7a-6c6d-4a83-90d7-b2e465245f87" />

## 작업 내용

Experience 섹션을 구현하고, Skills와 Experience에서 공통으로 사용하는 필터 구조를 정리했습니다.

### Experience 섹션 구현
- `src/content/experience.ts`
- Experience 데이터와 카테고리 타입을 분리해 관리할 수 있도록 구성했습니다.
- 카드에 필요한 타이틀, 기간, 설명, 태그, 아이콘 데이터를 정의했습니다.

### Experience UI 구현
- `src/sections/Experience.tsx`
- Experience 섹션 레이아웃과 카테고리 필터, 카드 UI를 구현했습니다.
- 카드 하단 화살표와 hover 인터랙션 디테일을 함께 정리했습니다.

### Experience 스타일 구성
- `src/sections/Experience.module.css`
- Experience 카드, 필터, 배지, 태그 스타일을 추가했습니다.
- 카드 hover 시 시각적 강조가 자연스럽게 보이도록 인터랙션을 보완했습니다.

### 스타일 / 구조 개선
- `src/components/SectionFilter.tsx`
- `src/components/SectionFilter.module.css`
- `src/sections/Skills.tsx`
- `src/sections/Skills.module.css`
- Skills와 Experience에서 공통으로 사용하는 필터 UI를 `SectionFilter` 컴포넌트로 분리했습니다.
- 필터 구조를 공통화하면서 Skills 섹션도 동일한 인터랙션 구조를 사용하도록 정리했습니다.
- `src/app/page.tsx`, `package.json`, `package-lock.json`에서 Experience 섹션 연결 및 아이콘 의존성 반영을 함께 진행했습니다.

## 피드백 받고 싶은 내용
1. Experience 카드의 시각적 밀도와 hover 인터랙션이 전체 포트폴리오와 잘 맞는지 궁금합니다.

## 관련 이슈
- Refs #4
